### PR TITLE
fix: strip LIST -a flag for curlftpfs compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -714,6 +714,7 @@ TEST_BINS += $(BUILD_DIR)/tests/test_alloc
 TEST_BINS += $(BUILD_DIR)/tests/test_mlst_ascii
 TEST_BINS += $(BUILD_DIR)/tests/test_http_query
 TEST_BINS += $(BUILD_DIR)/tests/test_http_confinement
+TEST_BINS += $(BUILD_DIR)/tests/test_list_flag
 
 ifeq ($(filter $(TARGET),linux macos),)
 test: $(OUTPUT_BIN)

--- a/include/ftp_path.h
+++ b/include/ftp_path.h
@@ -214,4 +214,21 @@ ftp_error_t ftp_path_join(const char *base,
                            char *output,
                            size_t size);
 
+/*===========================================================================*
+ * LIST FLAG DISAMBIGUATION
+ *===========================================================================*/
+
+/*
+ * Returns 1 if args start with a LIST flag (-a/-l/-la/-al) that
+ * should be stripped, 0 otherwise.  Single-token args (e.g. "LIST -a")
+ * are stat()'d relative to CWD to disambiguate flag from real path.
+ */
+int ftp_path_has_list_flag(const char *args, const char *cwd,
+                           char *scratch, size_t scratch_size);
+
+/*
+ * Strips the leading flag token; returns remainder or CWD.
+ */
+const char *ftp_path_skip_list_flag(const char *args, const char *cwd);
+
 #endif /* FTP_PATH_H */

--- a/src/ftp_commands.c
+++ b/src/ftp_commands.c
@@ -604,8 +604,19 @@ ftp_error_t cmd_LIST(ftp_session_t *session, const char *args) {
     return FTP_ERR_INVALID_PARAM;
   }
 
-  /* Resolve path (use CWD if no args) */
-  const char *path_arg = (args != NULL) ? args : session->cwd;
+  /*
+   * Strip well-known LIST flags (-a, -l, -la, -al) that clients like
+   * curlftpfs send by default.  Uses ProFTPD's have_options() heuristic:
+   * a single "-…" token is stat()'d to decide flag-vs-path.
+   */
+  char list_scratch[FTP_PATH_MAX];
+  const char *path_arg;
+  if (ftp_path_has_list_flag(args, session->cwd, list_scratch,
+                             sizeof(list_scratch))) {
+    path_arg = ftp_path_skip_list_flag(args, session->cwd);
+  } else {
+    path_arg = (args != NULL && *args != '\0') ? args : session->cwd;
+  }
 
   char resolved[FTP_PATH_MAX];
   ftp_error_t err =
@@ -662,8 +673,15 @@ ftp_error_t cmd_NLST(ftp_session_t *session, const char *args) {
     return FTP_ERR_INVALID_PARAM;
   }
 
-  /* Similar to LIST but simpler format */
-  const char *path_arg = (args != NULL) ? args : session->cwd;
+  /* Strip well-known NLST flags — same ProFTPD-style logic as cmd_LIST. */
+  char nlist_scratch[FTP_PATH_MAX];
+  const char *path_arg;
+  if (ftp_path_has_list_flag(args, session->cwd, nlist_scratch,
+                             sizeof(nlist_scratch))) {
+    path_arg = ftp_path_skip_list_flag(args, session->cwd);
+  } else {
+    path_arg = (args != NULL && *args != '\0') ? args : session->cwd;
+  }
 
   char resolved[FTP_PATH_MAX];
   ftp_error_t err =

--- a/src/ftp_path.c
+++ b/src/ftp_path.c
@@ -502,3 +502,54 @@ ftp_error_t ftp_path_join(const char *base,
     /* Normalize the joined path */
     return ftp_path_normalize(temp, output, size);
 }
+
+/*
+ * LIST flag disambiguation.
+ * curlftpfs sends "LIST -a" by default; treat "-a"/"-l"/"-la"/"-al"
+ * as flags (case-insensitive), stat single tokens to tell flag from path.
+ */
+static int is_list_flag_char(int c) {
+  return (c == 'a' || c == 'A' || c == 'l' || c == 'L');
+}
+
+static int is_list_flag(const char *s) {
+  if (s == NULL || *s != '-') return 0;
+  for (const char *p = s + 1; *p != '\0' && *p != ' '; p++)
+    if (!is_list_flag_char((unsigned char)*p)) return 0;
+  return s[1] != '\0';
+}
+
+static int has_multi_tokens(const char *s) {
+  while (*s != '\0' && *s != ' ') s++;
+  while (*s == ' ') s++;
+  return *s != '\0';
+}
+
+int ftp_path_has_list_flag(const char *args, const char *cwd,
+                           char *scratch, size_t scratch_size) {
+  if (args == NULL || *args == '\0') return 0;
+  if (!is_list_flag(args)) return 0;
+
+  /* args like "-a /data" → definitely a flag, strip it */
+  if (has_multi_tokens(args)) return 1;
+
+  /* Single token like "-a": stat(CWD/-a).
+   * Exists → path  (e.g. a directory actually named "-a")
+   * Absent → flag  (curlftpfs default) */
+  size_t cwd_len = strlen(cwd);
+  size_t arg_len = strlen(args);
+  size_t needed = cwd_len + 1U + arg_len + 1U;
+  if (needed > scratch_size) return 1;  /* buffer too small, assume flag */
+
+  memcpy(scratch, cwd, cwd_len);
+  if (cwd_len > 0U && cwd[cwd_len - 1U] != '/') scratch[cwd_len++] = '/';
+  memcpy(scratch + cwd_len, args, arg_len);
+  scratch[cwd_len + arg_len] = '\0';
+  return pal_path_exists(scratch) ? 0 : 1;  /* exists=path, absent=flag */
+}
+
+const char *ftp_path_skip_list_flag(const char *args, const char *cwd) {
+  while (*args != '\0' && *args != ' ') args++;
+  while (*args == ' ') args++;
+  return (*args == '\0') ? cwd : args;
+}

--- a/tests/test_list_flag.c
+++ b/tests/test_list_flag.c
@@ -1,0 +1,113 @@
+#include "ftp_path.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static int failed = 0;
+
+#define T(expr, expected) do { \
+  if ((expr) != (expected)) { \
+    fprintf(stderr, "FAIL:%d: %s → %d (expected %d)\n", \
+            __LINE__, #expr, (int)(expr), (int)(expected)); \
+    failed++; \
+  } \
+} while(0)
+
+static void test_has_list_flag(void) {
+  char scratch[FTP_PATH_MAX];
+  const char *cwd = "/";
+
+  /* NULL / empty args → no flag */
+  T(ftp_path_has_list_flag(NULL, cwd, scratch, sizeof(scratch)), 0);
+  T(ftp_path_has_list_flag("", cwd, scratch, sizeof(scratch)), 0);
+
+  /* Plain path → no flag */
+  T(ftp_path_has_list_flag("/data", cwd, scratch, sizeof(scratch)), 0);
+  T(ftp_path_has_list_flag("subdir", cwd, scratch, sizeof(scratch)), 0);
+
+  /* Known flags (single token) → flag */
+  T(ftp_path_has_list_flag("-a", cwd, scratch, sizeof(scratch)), 1);
+  T(ftp_path_has_list_flag("-l", cwd, scratch, sizeof(scratch)), 1);
+  T(ftp_path_has_list_flag("-al", cwd, scratch, sizeof(scratch)), 1);
+  T(ftp_path_has_list_flag("-la", cwd, scratch, sizeof(scratch)), 1);
+  T(ftp_path_has_list_flag("-A", cwd, scratch, sizeof(scratch)), 1);
+  T(ftp_path_has_list_flag("-LA", cwd, scratch, sizeof(scratch)), 1);
+
+  /* Known flag with path (multi-token) → flag */
+  T(ftp_path_has_list_flag("-a /data", cwd, scratch, sizeof(scratch)), 1);
+  T(ftp_path_has_list_flag("-l subdir", cwd, scratch, sizeof(scratch)), 1);
+  T(ftp_path_has_list_flag("-a  /mnt", cwd, scratch, sizeof(scratch)), 1);
+
+  /* Unknown chars after - → not a flag, treat as path */
+  T(ftp_path_has_list_flag("-R", cwd, scratch, sizeof(scratch)), 0);
+  T(ftp_path_has_list_flag("-t", cwd, scratch, sizeof(scratch)), 0);
+  T(ftp_path_has_list_flag("-d", cwd, scratch, sizeof(scratch)), 0);
+  T(ftp_path_has_list_flag("-x", cwd, scratch, sizeof(scratch)), 0);
+  T(ftp_path_has_list_flag("-myfile", cwd, scratch, sizeof(scratch)), 0);
+  T(ftp_path_has_list_flag("-aR", cwd, scratch, sizeof(scratch)), 0);
+
+  /* Lone dash → not a flag */
+  T(ftp_path_has_list_flag("-", cwd, scratch, sizeof(scratch)), 0);
+
+  /* Not a flag at all → no flag */
+  T(ftp_path_has_list_flag("README", cwd, scratch, sizeof(scratch)), 0);
+}
+
+static void test_skip_list_flag(void) {
+  const char *cwd = "/home";
+
+  T(strcmp(ftp_path_skip_list_flag("-a", cwd), cwd) == 0, 1);
+  T(strcmp(ftp_path_skip_list_flag("-al", cwd), cwd) == 0, 1);
+  T(strcmp(ftp_path_skip_list_flag("-la", cwd), cwd) == 0, 1);
+
+  T(strcmp(ftp_path_skip_list_flag("-a /data", cwd), "/data") == 0, 1);
+  T(strcmp(ftp_path_skip_list_flag("-a subdir", cwd), "subdir") == 0, 1);
+  T(strcmp(ftp_path_skip_list_flag("-a  /mnt", cwd), "/mnt") == 0, 1);
+}
+
+static void test_stat_disambiguation(void) {
+  char tmpdir[] = "/tmp/zftpd-list-test-XXXXXX";
+  if (mkdtemp(tmpdir) == NULL) {
+    fprintf(stderr, "SKIP: cannot create temp dir\n");
+    return;
+  }
+
+  char scratch[FTP_PATH_MAX];
+
+  /* Create a file named "-a" — should be treated as a path */
+  char path_a[256];
+  snprintf(path_a, sizeof(path_a), "%s/-a", tmpdir);
+  FILE *f = fopen(path_a, "w");
+  if (f) { fclose(f); }
+
+  T(ftp_path_has_list_flag("-a", tmpdir, scratch, sizeof(scratch)), 0);
+
+  /* Directory named "-al" should also be a path */
+  char path_al[256];
+  snprintf(path_al, sizeof(path_al), "%s/-al", tmpdir);
+  mkdir(path_al, 0700);
+  T(ftp_path_has_list_flag("-al", tmpdir, scratch, sizeof(scratch)), 0);
+
+  /* File that looks like flag + path */
+  T(ftp_path_has_list_flag("-a testfile", tmpdir, scratch, sizeof(scratch)), 1);
+
+  /* Cleanup */
+  unlink(path_a);
+  rmdir(path_al);
+  rmdir(tmpdir);
+}
+
+int main(void) {
+  test_has_list_flag();
+  test_skip_list_flag();
+  test_stat_disambiguation();
+
+  if (failed > 0) {
+    fprintf(stderr, "\n%d test(s) FAILED\n", failed);
+    return 1;
+  }
+  printf("test_list_flag: PASS\n");
+  return 0;
+}


### PR DESCRIPTION
curlftpfs defaults to "LIST -a" for directory listings.  zftpd passed
"-a" through to ftp_path_resolve() which resolved it to a non-existent
path "/-a", returning 550.  FUSE-based mounts (curlftpfs, trim_curlftpfs)
interpret this as I/O error and show an empty directory.

Pure-FTPd's dolist() in src/ls.c handles this by scanning the leading
token for recognized flag characters (a, l, etc.) and stripping them
before path resolution.  This patch follows the same approach:

- ftp_path_has_list_flag(): checks whether args start with a recognised
  flag (-a, -l, -la, -al, case-insensitive).  For a single-token args
  like "LIST -a", stat() is used to disambiguate: if a file named "-a"
  actually exists on disk, the token is treated as a path, not a flag.

- ftp_path_skip_list_flag(): strips the leading flag token and returns
  the remainder (or CWD if nothing follows).

Only characters {a, A, l, L} are recognised as flag content.  Any other
character (e.g. "LIST -R") makes the token pass through as a path, so
files whose names genuinely start with '-' remain accessible.

cmd_LIST and cmd_NLST are the only callers — other path-taking commands
should not receive flag arguments and are left unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * FTP directory listings now better handle common `LIST` and `NLST` flag options, including combined forms like `-a`, `-l`, `-al`, and `-la`.
* **Bug Fixes**
  * Improved path detection so listing requests are less likely to confuse a flag for a real file or folder.
  * Listing commands now fall back to the current directory more reliably when no path is provided.
* **Tests**
  * Added coverage for flag parsing and path disambiguation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->